### PR TITLE
Correct LIBDYNAMIXEL variable in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(dynamixel_control_hw)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
-set(LIBDYNAMIXEL "")
+set(LIBDYNAMIXEL "$ENV{LIBDYNAMIXEL}")
 
 find_package(catkin REQUIRED COMPONENTS
   roscpp


### PR DESCRIPTION
ビルドバグの修正です．本家のissue 31で返答がないのでこちらで取り急ぎ修正しようかと思います．
https://github.com/sbgisen/dynamixel_control_hw/blob/04c4d3b7141a9032c25380c463e6f40fc987085c/CMakeLists.txt#L25