### PR TITLE
Reboot all motors when the process is killed

### DIFF
--- a/include/dynamixel_control_hw/hardware_interface.hpp
+++ b/include/dynamixel_control_hw/hardware_interface.hpp
@@ -138,7 +138,10 @@ namespace dynamixel {
             for (auto dynamixel_servo : _servos) {
                 dynamixel::StatusPacket<Protocol> status;
                 _dynamixel_controller.send(dynamixel_servo->set_torque_enable(0));
-                _dynamixel_controller.recv(status);
+
+                // only works for X-series with Protocol2
+                usleep(100);
+                _dynamixel_controller.send(dynamixel_servo->reboot());
             }
         }
         catch (dynamixel::errors::Error& e) {


### PR DESCRIPTION
This PR depends on a change on https://github.com/sbgisen/libdynamixel/pull/6

In case some error occurs on a motor (e.g. overload or abnormal temperature is detected), reboot is required before restarting it.
Although this implementation may not the best way to realize it, it resolves our facing problems.